### PR TITLE
Fix empty provider location update

### DIFF
--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -20,8 +20,8 @@
 POM_NAME=LocationManager Library
 POM_ARTIFACT_ID=LocationManager
 POM_PACKAGING=aar
-VERSION_NAME=2.0.0
-VERSION_CODE=20
+VERSION_NAME=2.0.1
+VERSION_CODE=21
 GROUP=com.yayandroid
 
 POM_DESCRIPTION=LocationManager Library

--- a/library/src/main/java/com/yayandroid/locationmanager/helper/UpdateRequest.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/helper/UpdateRequest.java
@@ -26,7 +26,9 @@ public class UpdateRequest {
 
     @SuppressWarnings("ResourceType")
     public void run() {
-        locationManager.requestLocationUpdates(provider, minTime, minDistance, locationListener);
+        if(StringUtils.isNotEmpty(provider)) {
+            locationManager.requestLocationUpdates(provider, minTime, minDistance, locationListener);
+        }
     }
 
     @SuppressWarnings("ResourceType")


### PR DESCRIPTION
Fixes the issue: https://github.com/yayaa/LocationManager/issues/35

When user leaves the screen and comes back even before defaultLocationProvider starts asking for location updates, then it tries to requestLocationUpdate without any provider specified yet.