### PR TITLE
Fallback from GooglePlayServices to Default

### DIFF
--- a/library/src/main/java/com/yayandroid/locationmanager/configuration/Defaults.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/configuration/Defaults.java
@@ -18,6 +18,7 @@ public final class Defaults {
     static final float MIN_ACCURACY = 5.0f;
 
     static final boolean KEEP_TRACKING = false;
+    static final boolean FALLBACK_TO_DEFAULT = true;
     static final boolean ASK_FOR_GP_SERVICES = false;
     static final boolean ASK_FOR_SETTINGS_API = true;
     static final boolean FAIL_ON_CONNECTION_SUSPENDED = true;

--- a/library/src/main/java/com/yayandroid/locationmanager/configuration/GooglePlayServicesConfiguration.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/configuration/GooglePlayServicesConfiguration.java
@@ -3,10 +3,13 @@ package com.yayandroid.locationmanager.configuration;
 import android.support.annotation.NonNull;
 
 import com.google.android.gms.location.LocationRequest;
+import com.yayandroid.locationmanager.providers.locationprovider.DefaultLocationProvider;
+import com.yayandroid.locationmanager.providers.locationprovider.GooglePlayServicesLocationProvider;
 
 public class GooglePlayServicesConfiguration {
 
     private final LocationRequest locationRequest;
+    private final boolean fallbackToDefault;
     private final boolean askForGooglePlayServices;
     private final boolean askForSettingsApi;
     private final boolean failOnConnectionSuspended;
@@ -17,6 +20,7 @@ public class GooglePlayServicesConfiguration {
 
     private GooglePlayServicesConfiguration(Builder builder) {
         this.locationRequest = builder.locationRequest;
+        this.fallbackToDefault = builder.fallbackToDefault;
         this.askForGooglePlayServices = builder.askForGooglePlayServices;
         this.askForSettingsApi = builder.askForSettingsApi;
         this.failOnConnectionSuspended = builder.failOnConnectionSuspended;
@@ -29,6 +33,7 @@ public class GooglePlayServicesConfiguration {
     public GooglePlayServicesConfiguration.Builder newBuilder() {
         return new GooglePlayServicesConfiguration.Builder()
               .locationRequest(locationRequest)
+              .fallbackToDefault(fallbackToDefault)
               .askForGooglePlayServices(askForGooglePlayServices)
               .askForSettingsApi(askForSettingsApi)
               .failOnConnectionSuspended(failOnConnectionSuspended)
@@ -41,6 +46,10 @@ public class GooglePlayServicesConfiguration {
     // region Getters
     public LocationRequest locationRequest() {
         return locationRequest;
+    }
+
+    public boolean fallbackToDefault() {
+        return fallbackToDefault;
     }
 
     public boolean askForGooglePlayServices() {
@@ -75,6 +84,7 @@ public class GooglePlayServicesConfiguration {
     public static class Builder {
 
         private LocationRequest locationRequest = Defaults.createDefaultLocationRequest();
+        private boolean fallbackToDefault = Defaults.FALLBACK_TO_DEFAULT;
         private boolean askForGooglePlayServices = Defaults.ASK_FOR_GP_SERVICES;
         private boolean askForSettingsApi = Defaults.ASK_FOR_SETTINGS_API;
         private boolean failOnConnectionSuspended = Defaults.FAIL_ON_CONNECTION_SUSPENDED;
@@ -89,6 +99,16 @@ public class GooglePlayServicesConfiguration {
          */
         public Builder locationRequest(@NonNull LocationRequest locationRequest) {
             this.locationRequest = locationRequest;
+            return this;
+        }
+
+        /**
+         * In case of getting location from {@linkplain GooglePlayServicesLocationProvider} fails,
+         * library will fallback to {@linkplain DefaultLocationProvider} as a default behaviour.
+         * If you set this to false, then library will notify fail as soon as GooglePlayServicesLocationProvider fails.
+         */
+        public Builder fallbackToDefault(boolean fallbackToDefault) {
+            this.fallbackToDefault = fallbackToDefault;
             return this;
         }
 

--- a/library/src/main/java/com/yayandroid/locationmanager/configuration/LocationConfiguration.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/configuration/LocationConfiguration.java
@@ -2,17 +2,21 @@ package com.yayandroid.locationmanager.configuration;
 
 import android.support.annotation.Nullable;
 
+import com.yayandroid.locationmanager.providers.locationprovider.DefaultLocationProvider;
+import com.yayandroid.locationmanager.providers.locationprovider.GooglePlayServicesLocationProvider;
 import com.yayandroid.locationmanager.providers.permissionprovider.StubPermissionProvider;
 
 public class LocationConfiguration {
 
     private final boolean keepTracking;
+    private final boolean fallbackToDefault;
     private final PermissionConfiguration permissionConfiguration;
     private final GooglePlayServicesConfiguration googlePlayServicesConfiguration;
     private final DefaultProviderConfiguration defaultProviderConfiguration;
 
     private LocationConfiguration(Builder builder) {
         this.keepTracking = builder.keepTracking;
+        this.fallbackToDefault = builder.fallbackToDefault;
         this.permissionConfiguration = builder.permissionConfiguration;
         this.googlePlayServicesConfiguration = builder.googlePlayServicesConfiguration;
         this.defaultProviderConfiguration = builder.defaultProviderConfiguration;
@@ -21,6 +25,7 @@ public class LocationConfiguration {
     public LocationConfiguration.Builder newBuilder() {
         return new LocationConfiguration.Builder()
               .keepTracking(keepTracking)
+              .fallbackToDefault(fallbackToDefault)
               .askForPermission(permissionConfiguration)
               .useGooglePlayServices(googlePlayServicesConfiguration)
               .useDefaultProviders(defaultProviderConfiguration);
@@ -29,6 +34,10 @@ public class LocationConfiguration {
     // region Getters
     public boolean keepTracking() {
         return keepTracking;
+    }
+
+    public boolean fallbackToDefault() {
+        return fallbackToDefault;
     }
 
     public PermissionConfiguration permissionConfiguration() {
@@ -47,6 +56,7 @@ public class LocationConfiguration {
     public static class Builder {
 
         private boolean keepTracking = Defaults.KEEP_TRACKING;
+        private boolean fallbackToDefault = Defaults.FALLBACK_TO_DEFAULT;
         private PermissionConfiguration permissionConfiguration;
         private GooglePlayServicesConfiguration googlePlayServicesConfiguration;
         private DefaultProviderConfiguration defaultProviderConfiguration;
@@ -58,6 +68,16 @@ public class LocationConfiguration {
          */
         public Builder keepTracking(boolean keepTracking) {
             this.keepTracking = keepTracking;
+            return this;
+        }
+
+        /**
+         * In case of getting location from {@linkplain GooglePlayServicesLocationProvider} fails,
+         * library will fallback to {@linkplain DefaultLocationProvider} as a default behaviour.
+         * If you set this to false, then library will notify to fail as soon as GooglePlayServicesLocationProvider fails.
+         */
+        public Builder fallbackToDefault(boolean fallbackToDefault) {
+            this.fallbackToDefault = fallbackToDefault;
             return this;
         }
 

--- a/library/src/main/java/com/yayandroid/locationmanager/configuration/LocationConfiguration.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/configuration/LocationConfiguration.java
@@ -9,14 +9,12 @@ import com.yayandroid.locationmanager.providers.permissionprovider.StubPermissio
 public class LocationConfiguration {
 
     private final boolean keepTracking;
-    private final boolean fallbackToDefault;
     private final PermissionConfiguration permissionConfiguration;
     private final GooglePlayServicesConfiguration googlePlayServicesConfiguration;
     private final DefaultProviderConfiguration defaultProviderConfiguration;
 
     private LocationConfiguration(Builder builder) {
         this.keepTracking = builder.keepTracking;
-        this.fallbackToDefault = builder.fallbackToDefault;
         this.permissionConfiguration = builder.permissionConfiguration;
         this.googlePlayServicesConfiguration = builder.googlePlayServicesConfiguration;
         this.defaultProviderConfiguration = builder.defaultProviderConfiguration;
@@ -25,7 +23,6 @@ public class LocationConfiguration {
     public LocationConfiguration.Builder newBuilder() {
         return new LocationConfiguration.Builder()
               .keepTracking(keepTracking)
-              .fallbackToDefault(fallbackToDefault)
               .askForPermission(permissionConfiguration)
               .useGooglePlayServices(googlePlayServicesConfiguration)
               .useDefaultProviders(defaultProviderConfiguration);
@@ -34,10 +31,6 @@ public class LocationConfiguration {
     // region Getters
     public boolean keepTracking() {
         return keepTracking;
-    }
-
-    public boolean fallbackToDefault() {
-        return fallbackToDefault;
     }
 
     public PermissionConfiguration permissionConfiguration() {
@@ -56,7 +49,6 @@ public class LocationConfiguration {
     public static class Builder {
 
         private boolean keepTracking = Defaults.KEEP_TRACKING;
-        private boolean fallbackToDefault = Defaults.FALLBACK_TO_DEFAULT;
         private PermissionConfiguration permissionConfiguration;
         private GooglePlayServicesConfiguration googlePlayServicesConfiguration;
         private DefaultProviderConfiguration defaultProviderConfiguration;
@@ -68,16 +60,6 @@ public class LocationConfiguration {
          */
         public Builder keepTracking(boolean keepTracking) {
             this.keepTracking = keepTracking;
-            return this;
-        }
-
-        /**
-         * In case of getting location from {@linkplain GooglePlayServicesLocationProvider} fails,
-         * library will fallback to {@linkplain DefaultLocationProvider} as a default behaviour.
-         * If you set this to false, then library will notify to fail as soon as GooglePlayServicesLocationProvider fails.
-         */
-        public Builder fallbackToDefault(boolean fallbackToDefault) {
-            this.fallbackToDefault = fallbackToDefault;
             return this;
         }
 

--- a/library/src/main/java/com/yayandroid/locationmanager/listener/FallbackListener.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/listener/FallbackListener.java
@@ -1,0 +1,5 @@
+package com.yayandroid.locationmanager.listener;
+
+public interface FallbackListener {
+    void onFallback();
+}

--- a/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DispatcherLocationProvider.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DispatcherLocationProvider.java
@@ -10,8 +10,9 @@ import com.yayandroid.locationmanager.constants.FailType;
 import com.yayandroid.locationmanager.constants.RequestCode;
 import com.yayandroid.locationmanager.helper.LogUtils;
 import com.yayandroid.locationmanager.helper.continuoustask.ContinuousTask.ContinuousTaskRunner;
+import com.yayandroid.locationmanager.listener.FallbackListener;
 
-public class DispatcherLocationProvider extends LocationProvider implements ContinuousTaskRunner {
+public class DispatcherLocationProvider extends LocationProvider implements ContinuousTaskRunner, FallbackListener {
 
     private Dialog gpServicesDialog;
     private LocationProvider activeProvider;
@@ -117,6 +118,13 @@ public class DispatcherLocationProvider extends LocationProvider implements Cont
         }
     }
 
+    @Override
+    public void onFallback() {
+        // This is called from GooglePlayServicesLocationProvider when it fails to before its scheduled time
+        cancel();
+        continueWithDefaultProviders();
+    }
+
     void checkGooglePlayServicesAvailability(boolean askForGooglePlayServices) {
         int gpServicesAvailability = getSourceProvider().isGoogleApiAvailable(getContext());
 
@@ -173,7 +181,7 @@ public class DispatcherLocationProvider extends LocationProvider implements Cont
 
     void getLocationFromGooglePlayServices() {
         LogUtils.logI("Attempting to get location from Google Play Services providers...");
-        setLocationProvider(getSourceProvider().createGooglePlayServicesLocationProvider());
+        setLocationProvider(getSourceProvider().createGooglePlayServicesLocationProvider(this));
         getSourceProvider().gpServicesSwitchTask().delayed(getConfiguration()
               .googlePlayServicesConfiguration().googlePlayServicesWaitPeriod());
         activeProvider.get();

--- a/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DispatcherLocationSource.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DispatcherLocationSource.java
@@ -9,6 +9,7 @@ import android.support.annotation.Nullable;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.yayandroid.locationmanager.helper.continuoustask.ContinuousTask;
 import com.yayandroid.locationmanager.helper.continuoustask.ContinuousTask.ContinuousTaskRunner;
+import com.yayandroid.locationmanager.listener.FallbackListener;
 
 class DispatcherLocationSource {
 
@@ -20,8 +21,8 @@ class DispatcherLocationSource {
         return new DefaultLocationProvider();
     }
 
-    GooglePlayServicesLocationProvider createGooglePlayServicesLocationProvider() {
-        return new GooglePlayServicesLocationProvider();
+    GooglePlayServicesLocationProvider createGooglePlayServicesLocationProvider(FallbackListener fallbackListener) {
+        return new GooglePlayServicesLocationProvider(fallbackListener);
     }
 
     void createSwitchTask(ContinuousTaskRunner continuousTaskRunner) {

--- a/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/GooglePlayServicesLocationProvider.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/GooglePlayServicesLocationProvider.java
@@ -252,7 +252,7 @@ public class GooglePlayServicesLocationProvider extends LocationProvider impleme
     }
 
     void failed(@FailType int type) {
-        if (getConfiguration().fallbackToDefault() && fallbackListener.get() != null) {
+        if (getConfiguration().googlePlayServicesConfiguration().fallbackToDefault() && fallbackListener.get() != null) {
             fallbackListener.get().onFallback();
         } else {
             if (getListener() != null) {

--- a/library/src/test/java/com/yayandroid/locationmanager/configuration/GooglePlayServicesConfigurationTest.java
+++ b/library/src/test/java/com/yayandroid/locationmanager/configuration/GooglePlayServicesConfigurationTest.java
@@ -20,6 +20,7 @@ public class GooglePlayServicesConfigurationTest {
     @Test public void checkDefaultValues() {
         GooglePlayServicesConfiguration configuration = new GooglePlayServicesConfiguration.Builder().build();
         assertThat(configuration.locationRequest()).isEqualTo(createDefaultLocationRequest());
+        assertThat(configuration.fallbackToDefault()).isTrue();
         assertThat(configuration.askForGooglePlayServices()).isFalse();
         assertThat(configuration.askForSettingsApi()).isTrue();
         assertThat(configuration.failOnConnectionSuspended()).isTrue();

--- a/library/src/test/java/com/yayandroid/locationmanager/configuration/LocationConfigurationTest.java
+++ b/library/src/test/java/com/yayandroid/locationmanager/configuration/LocationConfigurationTest.java
@@ -25,7 +25,6 @@ public class LocationConfigurationTest {
     @Test public void checkDefaultValues() {
         LocationConfiguration configuration = getConfiguration();
         assertThat(configuration.keepTracking()).isFalse();
-        assertThat(configuration.fallbackToDefault()).isTrue();
     }
 
     @Test public void whenNoPermissionConfigurationIsSetDefaultConfigurationShouldContainStubProvider() {

--- a/library/src/test/java/com/yayandroid/locationmanager/configuration/LocationConfigurationTest.java
+++ b/library/src/test/java/com/yayandroid/locationmanager/configuration/LocationConfigurationTest.java
@@ -25,6 +25,7 @@ public class LocationConfigurationTest {
     @Test public void checkDefaultValues() {
         LocationConfiguration configuration = getConfiguration();
         assertThat(configuration.keepTracking()).isFalse();
+        assertThat(configuration.fallbackToDefault()).isTrue();
     }
 
     @Test public void whenNoPermissionConfigurationIsSetDefaultConfigurationShouldContainStubProvider() {

--- a/library/src/test/java/com/yayandroid/locationmanager/providers/locationprovider/DispatcherLocationProviderTest.java
+++ b/library/src/test/java/com/yayandroid/locationmanager/providers/locationprovider/DispatcherLocationProviderTest.java
@@ -66,8 +66,8 @@ public class DispatcherLocationProviderTest {
         when(googlePlayServicesConfiguration.googlePlayServicesWaitPeriod()).thenReturn(GOOGLE_PLAY_SERVICES_SWITCH_PERIOD);
 
         when(dispatcherLocationSource.createDefaultLocationProvider()).thenReturn(defaultLocationProvider);
-        when(dispatcherLocationSource.createGooglePlayServicesLocationProvider()).thenReturn(
-              googlePlayServicesLocationProvider);
+        when(dispatcherLocationSource.createGooglePlayServicesLocationProvider(dispatcherLocationProvider))
+              .thenReturn(googlePlayServicesLocationProvider);
         when(dispatcherLocationSource.gpServicesSwitchTask()).thenReturn(continuousTask);
 
         when(contextProcessor.getContext()).thenReturn(context);
@@ -218,6 +218,14 @@ public class DispatcherLocationProviderTest {
         dispatcherLocationProvider.get();
 
         verify(dispatcherLocationProvider).checkGooglePlayServicesAvailability(eq(true));
+    }
+
+    @Test
+    public void onFallbackShouldCallCancelAndContinueWithDefaultProviders() {
+        dispatcherLocationProvider.onFallback();
+
+        verify(dispatcherLocationProvider).cancel();
+        verify(dispatcherLocationProvider).continueWithDefaultProviders();
     }
 
     @Test

--- a/library/src/test/java/com/yayandroid/locationmanager/providers/locationprovider/GooglePlayServicesLocationProviderTest.java
+++ b/library/src/test/java/com/yayandroid/locationmanager/providers/locationprovider/GooglePlayServicesLocationProviderTest.java
@@ -14,6 +14,7 @@ import com.yayandroid.locationmanager.configuration.LocationConfiguration;
 import com.yayandroid.locationmanager.constants.FailType;
 import com.yayandroid.locationmanager.constants.ProcessType;
 import com.yayandroid.locationmanager.constants.RequestCode;
+import com.yayandroid.locationmanager.listener.FallbackListener;
 import com.yayandroid.locationmanager.listener.LocationListener;
 import com.yayandroid.locationmanager.view.ContextProcessor;
 
@@ -43,6 +44,7 @@ public class GooglePlayServicesLocationProviderTest {
 
     @Mock LocationConfiguration locationConfiguration;
     @Mock GooglePlayServicesConfiguration googlePlayServicesConfiguration;
+    @Mock FallbackListener fallbackListener;
 
     private GooglePlayServicesLocationProvider googlePlayServicesLocationProvider;
 
@@ -50,7 +52,7 @@ public class GooglePlayServicesLocationProviderTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        googlePlayServicesLocationProvider = spy(new GooglePlayServicesLocationProvider());
+        googlePlayServicesLocationProvider = spy(new GooglePlayServicesLocationProvider(fallbackListener));
         googlePlayServicesLocationProvider.configure(contextProcessor, locationConfiguration, locationListener);
         googlePlayServicesLocationProvider.setDispatcherLocationSource(mockedSource);
 
@@ -450,10 +452,21 @@ public class GooglePlayServicesLocationProviderTest {
     }
 
     @Test
-    public void failedShouldRedirectToListener() {
+    public void failedShouldRedirectToListenerWhenFallbackToDefaultIsFalse() {
+        when(googlePlayServicesConfiguration.fallbackToDefault()).thenReturn(false);
+
         googlePlayServicesLocationProvider.failed(FailType.UNKNOWN);
 
         verify(locationListener).onLocationFailed(FailType.UNKNOWN);
+    }
+
+    @Test
+    public void failedShouldCallFallbackWhenFallbackToDefaultIsTrue() {
+        when(googlePlayServicesConfiguration.fallbackToDefault()).thenReturn(true);
+
+        googlePlayServicesLocationProvider.failed(FailType.UNKNOWN);
+
+        verify(fallbackListener).onFallback();
     }
 
     @Test


### PR DESCRIPTION
When GooglePlayServices is not fast enough to receive a location update, library switches back to default location providers, but not when GooglePlayServices fails to receive location.

With this PR, it will also fallback to default location providers when GooglePlayServices fails to receive location even within the required time period. It is possible to disable it by configuration, of course.