### PR TITLE
Fix same location update calls

### DIFF
--- a/library/src/main/java/com/yayandroid/locationmanager/helper/UpdateRequest.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/helper/UpdateRequest.java
@@ -17,6 +17,10 @@ public class UpdateRequest {
         this.locationListener = locationListener;
     }
 
+    public boolean isRequiredImmediately() {
+        return minTime == 0;
+    }
+
     public void run(String provider, long minTime, float minDistance) {
         this.provider = provider;
         this.minTime = minTime;

--- a/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProvider.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProvider.java
@@ -227,11 +227,14 @@ public class DefaultLocationProvider extends LocationProvider
         // no need to switch or call fail
         getSourceProvider().getProviderSwitchTask().stop();
 
+        // Remove update requests if it is running for immediate request
+        if (getSourceProvider().getUpdateRequest().isRequiredImmediately() || !getConfiguration().keepTracking()) {
+            getSourceProvider().removeLocationUpdates(this);
+        }
+
         if (getConfiguration().keepTracking()) {
             requestUpdateLocation(getConfiguration().defaultProviderConfiguration().requiredTimeInterval(),
                   getConfiguration().defaultProviderConfiguration().requiredDistanceInterval(), false);
-        } else {
-            getSourceProvider().removeLocationUpdates(this);
         }
     }
 

--- a/library/src/test/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProviderTest.java
+++ b/library/src/test/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProviderTest.java
@@ -392,7 +392,18 @@ public class DefaultLocationProviderTest {
     }
 
     @Test
+    public void onLocationChangedShouldRemoveUpdatesWhenRequiredImmediately() {
+        when(locationConfiguration.keepTracking()).thenReturn(true);
+        when(updateRequest.isRequiredImmediately()).thenReturn(true);
+
+        defaultLocationProvider.onLocationChanged(DUMMY_LOCATION);
+
+        verify(defaultLocationSource).removeLocationUpdates(defaultLocationProvider);
+    }
+
+    @Test
     public void onLocationChangedShouldRemoveUpdatesWhenKeepTrackingIsFalse() {
+        when(updateRequest.isRequiredImmediately()).thenReturn(false);
         when(locationConfiguration.keepTracking()).thenReturn(false);
 
         defaultLocationProvider.onLocationChanged(DUMMY_LOCATION);


### PR DESCRIPTION
To retrieve the location for the first time, library requests location update as minTimeInterval 0 and this might cause some multiple calls for onLocationChanged even though it actually doesn't.

This adapts the logic to remove update request once onLocationChanged is called, and re-schedule with required time & distance intervals if only _keepTracking_ required.

Issue: https://github.com/yayaa/LocationManager/issues/64