### PR TITLE
Disable Test Coverage For Release BuildType

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,7 +15,6 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            testCoverageEnabled true
         }
         debug {
             testCoverageEnabled true


### PR DESCRIPTION
Jacoco creates some problem on Application launch time. 
So it is better to disable for at least `release` version of the library.

https://stackoverflow.com/a/39195755/1171484