### PR TITLE
bugfix: add a NPE protection.

### DIFF
--- a/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProvider.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProvider.java
@@ -221,14 +221,16 @@ public class DefaultLocationProvider extends LocationProvider
 
     @Override
     public void onLocationChanged(Location location) {
-        if (getSourceProvider().switchTaskIsRemoved() || getSourceProvider().updateRequestIsRemoved()) {
+        if (getSourceProvider().updateRequestIsRemoved()) {
             return;
         }
         onLocationReceived(location);
 
         // Remove cancelLocationTask because we have already find location,
         // no need to switch or call fail
-        getSourceProvider().getProviderSwitchTask().stop();
+        if (!getSourceProvider().switchTaskIsRemoved()) {
+            getSourceProvider().getProviderSwitchTask().stop();
+        }
 
         // Remove update requests if it is running for immediate request
         if (getSourceProvider().getUpdateRequest().isRequiredImmediately() || !getConfiguration().keepTracking()) {

--- a/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProvider.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProvider.java
@@ -221,7 +221,7 @@ public class DefaultLocationProvider extends LocationProvider
 
     @Override
     public void onLocationChanged(Location location) {
-        if (getSourceProvider() == null) {
+        if (getSourceProvider().switchTaskIsRemoved() || getSourceProvider().updateRequestIsRemoved()) {
             return;
         }
         onLocationReceived(location);

--- a/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProvider.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProvider.java
@@ -221,6 +221,9 @@ public class DefaultLocationProvider extends LocationProvider
 
     @Override
     public void onLocationChanged(Location location) {
+        if (getSourceProvider() == null) {
+            return;
+        }
         onLocationReceived(location);
 
         // Remove cancelLocationTask because we have already find location,

--- a/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationSource.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationSource.java
@@ -55,6 +55,14 @@ class DefaultLocationSource {
         cancelTask = null;
     }
 
+    boolean switchTaskIsRemoved() {
+        return cancelTask == null;
+    }
+
+    boolean updateRequestIsRemoved() {
+        return updateRequest == null;
+    }
+
     ContinuousTask getProviderSwitchTask() {
         return cancelTask;
     }

--- a/library/src/test/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProviderTest.java
+++ b/library/src/test/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProviderTest.java
@@ -392,6 +392,22 @@ public class DefaultLocationProviderTest {
     }
 
     @Test
+    public void onLocationChangedShouldReurnIfSwitchTaskIsRemoved() {
+        when(defaultLocationSource.switchTaskIsRemoved()).thenReturn(true);
+
+        defaultLocationProvider.onLocationChanged(DUMMY_LOCATION);
+        verify(defaultLocationProvider, never()).onLocationReceived(DUMMY_LOCATION);
+    }
+
+    @Test
+    public void onLocationChangedShouldReturnIfUpdateRequestIsRemoved() {
+        when(defaultLocationSource.updateRequestIsRemoved()).thenReturn(true);
+
+        defaultLocationProvider.onLocationChanged(DUMMY_LOCATION);
+        verify(defaultLocationProvider, never()).onLocationReceived(DUMMY_LOCATION);
+    }
+
+    @Test
     public void onLocationChangedShouldRemoveUpdatesWhenRequiredImmediately() {
         when(locationConfiguration.keepTracking()).thenReturn(true);
         when(updateRequest.isRequiredImmediately()).thenReturn(true);

--- a/library/src/test/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProviderTest.java
+++ b/library/src/test/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProviderTest.java
@@ -392,11 +392,11 @@ public class DefaultLocationProviderTest {
     }
 
     @Test
-    public void onLocationChangedShouldReurnIfSwitchTaskIsRemoved() {
+    public void onLocationChangedShouldNotStopSwitchTaskIfSwitchTaskIsRemoved() {
         when(defaultLocationSource.switchTaskIsRemoved()).thenReturn(true);
 
         defaultLocationProvider.onLocationChanged(DUMMY_LOCATION);
-        verify(defaultLocationProvider, never()).onLocationReceived(DUMMY_LOCATION);
+        verify(continuousTask, never()).stop();
     }
 
     @Test


### PR DESCRIPTION
The `onLocationChanged(Location location)` callback is actually called in a thread's looper, which created the LocationManager.
So, event if the `DefaultLocationProvider.onDestroy()` is done, the message which has the callback,  may not be destroyed (because the `removeUpdates(LocationListener listener)` method will call a system service, which is another process), and still in the looper's message queue. At this moment, executing `onLocationChanged(Location location)` will cause a Null Point Exception, as `getSourceProvider()` returns null.