### PR TITLE
add an interface for more custom logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ It is highly recommended to disable in release mode.
 LocationManager.enableLog(false);
 ```
 
+For a more fine tuned logging, you can provide a custom Logger implementation to filter and delegate logs as you need it.
+
+```java
+Logger myCustomLoggerImplementation = new MyCustomLoggerImplementation();
+LocationManager.setLogger(myCustomLoggerImplementation);
+```
+
 ## Restrictions
 If you are using LocationManager in a
 - Fragment, you need to redirect your `onActivityResult` to fragment manually, because GooglePlayServices Api and SettingsApi calls `startActivityForResult` from activity. For the sample implementation please see [SampleFragmentActivity][15].

--- a/library/src/main/java/com/yayandroid/locationmanager/LocationManager.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/LocationManager.java
@@ -11,6 +11,8 @@ import com.yayandroid.locationmanager.configuration.LocationConfiguration;
 import com.yayandroid.locationmanager.constants.FailType;
 import com.yayandroid.locationmanager.constants.ProcessType;
 import com.yayandroid.locationmanager.helper.LogUtils;
+import com.yayandroid.locationmanager.helper.logging.DefaultLogger;
+import com.yayandroid.locationmanager.helper.logging.Logger;
 import com.yayandroid.locationmanager.listener.LocationListener;
 import com.yayandroid.locationmanager.listener.PermissionListener;
 import com.yayandroid.locationmanager.providers.locationprovider.DispatcherLocationProvider;
@@ -33,6 +35,14 @@ public class LocationManager implements PermissionListener {
      */
     public static void enableLog(boolean enable) {
         LogUtils.enable(enable);
+    }
+
+    /**
+     * The Logger specifies how this Library is logging debug information. By default {@link DefaultLogger}
+     * is used and it can be replaces by your own custom implementation of {@link Logger}.
+     */
+    public static void setLogger(Logger logger) {
+        LogUtils.setLogger(logger);
     }
 
     /**

--- a/library/src/main/java/com/yayandroid/locationmanager/LocationManager.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/LocationManager.java
@@ -41,7 +41,7 @@ public class LocationManager implements PermissionListener {
      * The Logger specifies how this Library is logging debug information. By default {@link DefaultLogger}
      * is used and it can be replaced by your own custom implementation of {@link Logger}.
      */
-    public static void setLogger(Logger logger) {
+    public static void setLogger(@NonNull Logger logger) {
         LogUtils.setLogger(logger);
     }
 

--- a/library/src/main/java/com/yayandroid/locationmanager/LocationManager.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/LocationManager.java
@@ -39,7 +39,7 @@ public class LocationManager implements PermissionListener {
 
     /**
      * The Logger specifies how this Library is logging debug information. By default {@link DefaultLogger}
-     * is used and it can be replaces by your own custom implementation of {@link Logger}.
+     * is used and it can be replaced by your own custom implementation of {@link Logger}.
      */
     public static void setLogger(Logger logger) {
         LogUtils.setLogger(logger);

--- a/library/src/main/java/com/yayandroid/locationmanager/helper/LogUtils.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/helper/LogUtils.java
@@ -1,10 +1,13 @@
 package com.yayandroid.locationmanager.helper;
 
-import android.util.Log;
+import com.yayandroid.locationmanager.helper.logging.DefaultLogger;
+import com.yayandroid.locationmanager.helper.logging.Logger;
 
 public final class LogUtils {
 
     private static boolean isEnabled = false;
+
+    private static Logger activeLogger = new DefaultLogger();
 
     private LogUtils() {
         // No instance
@@ -14,24 +17,28 @@ public final class LogUtils {
         LogUtils.isEnabled = isEnabled;
     }
 
+    public static void setLogger(Logger logger) {
+        if (logger != null) activeLogger = logger;
+    }
+
     public static void logD(String message) {
-        if (isEnabled) Log.d(getClassName(), message);
+        if (isEnabled) activeLogger.logD(getClassName(), message);
     }
 
     public static void logE(String message) {
-        if (isEnabled) Log.e(getClassName(), message);
+        if (isEnabled) activeLogger.logE(getClassName(), message);
     }
 
     public static void logI(String message) {
-        if (isEnabled) Log.i(getClassName(), message);
+        if (isEnabled) activeLogger.logI(getClassName(), message);
     }
 
     public static void logV(String message) {
-        if (isEnabled) Log.v(getClassName(), message);
+        if (isEnabled) activeLogger.logV(getClassName(), message);
     }
 
     public static void logW(String message) {
-        if (isEnabled) Log.w(getClassName(), message);
+        if (isEnabled) activeLogger.logW(getClassName(), message);
     }
 
     private static String getClassName() {

--- a/library/src/main/java/com/yayandroid/locationmanager/helper/LogUtils.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/helper/LogUtils.java
@@ -1,5 +1,7 @@
 package com.yayandroid.locationmanager.helper;
 
+import androidx.annotation.NonNull;
+
 import com.yayandroid.locationmanager.helper.logging.DefaultLogger;
 import com.yayandroid.locationmanager.helper.logging.Logger;
 
@@ -17,8 +19,8 @@ public final class LogUtils {
         LogUtils.isEnabled = isEnabled;
     }
 
-    public static void setLogger(Logger logger) {
-        if (logger != null) activeLogger = logger;
+    public static void setLogger(@NonNull Logger logger) {
+        activeLogger = logger;
     }
 
     public static void logD(String message) {

--- a/library/src/main/java/com/yayandroid/locationmanager/helper/logging/DefaultLogger.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/helper/logging/DefaultLogger.java
@@ -1,0 +1,25 @@
+package com.yayandroid.locationmanager.helper.logging;
+
+import android.util.Log;
+
+public class DefaultLogger implements Logger {
+    public void logD(String className, String message) {
+        Log.d(className, message);
+    }
+
+    public void logE(String className, String message) {
+        Log.e(className, message);
+    }
+
+    public void logI(String className, String message) {
+        Log.i(className, message);
+    }
+
+    public void logV(String className, String message) {
+        Log.v(className, message);
+    }
+
+    public void logW(String className, String message) {
+        Log.w(className, message);
+    }
+}

--- a/library/src/main/java/com/yayandroid/locationmanager/helper/logging/Logger.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/helper/logging/Logger.java
@@ -1,0 +1,13 @@
+package com.yayandroid.locationmanager.helper.logging;
+
+public interface Logger {
+    void logD(String className, String message);
+
+    void logE(String className, String message);
+
+    void logI(String className, String message);
+
+    void logV(String className, String message);
+
+    void logW(String className, String message);
+}

--- a/library/src/test/java/com/yayandroid/locationmanager/helper/LogUtilsTest.java
+++ b/library/src/test/java/com/yayandroid/locationmanager/helper/LogUtilsTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 public class LogUtilsTest {
@@ -34,11 +35,7 @@ public class LogUtilsTest {
         LogUtils.logV("Vmessage");
         LogUtils.logW("Wmessage");
 
-        verify(mockLogger, times(0)).logD(anyString(), anyString());
-        verify(mockLogger, times(0)).logE(anyString(), anyString());
-        verify(mockLogger, times(0)).logI(anyString(), anyString());
-        verify(mockLogger, times(0)).logV(anyString(), anyString());
-        verify(mockLogger, times(0)).logW(anyString(), anyString());
+        verifyZeroInteractions(mockLogger);
     }
 
     @Test

--- a/library/src/test/java/com/yayandroid/locationmanager/helper/LogUtilsTest.java
+++ b/library/src/test/java/com/yayandroid/locationmanager/helper/LogUtilsTest.java
@@ -1,0 +1,82 @@
+package com.yayandroid.locationmanager.helper;
+
+import com.yayandroid.locationmanager.helper.logging.Logger;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+public class LogUtilsTest {
+
+    @Mock
+    private Logger mockLogger;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        LogUtils.setLogger(mockLogger);
+    }
+
+    @Test
+    public void whenLoggingIsDisabledItShouldNotForwardToLogger() {
+        LogUtils.enable(false);
+
+        LogUtils.logD("Dmessage");
+        LogUtils.logE("Emessage");
+        LogUtils.logI("Imessage");
+        LogUtils.logV("Vmessage");
+        LogUtils.logW("Wmessage");
+
+        verify(mockLogger, times(0)).logD(anyString(), anyString());
+        verify(mockLogger, times(0)).logE(anyString(), anyString());
+        verify(mockLogger, times(0)).logI(anyString(), anyString());
+        verify(mockLogger, times(0)).logV(anyString(), anyString());
+        verify(mockLogger, times(0)).logW(anyString(), anyString());
+    }
+
+    @Test
+    public void whenLoggingIsEnabledItShouldForwardToLogger() {
+        LogUtils.enable(true);
+
+        LogUtils.logD("Dmessage");
+        LogUtils.logE("Emessage");
+        LogUtils.logI("Imessage");
+        LogUtils.logV("Vmessage");
+        LogUtils.logW("Wmessage");
+
+        verify(mockLogger, times(1)).logD(anyString(), eq("Dmessage"));
+        verify(mockLogger, times(1)).logE(anyString(), eq("Emessage"));
+        verify(mockLogger, times(1)).logI(anyString(), eq("Imessage"));
+        verify(mockLogger, times(1)).logV(anyString(), eq("Vmessage"));
+        verify(mockLogger, times(1)).logW(anyString(), eq("Wmessage"));
+    }
+
+    @Test
+    public void whenChangingLoggerItShouldLogIntoIt() {
+        LogUtils.enable(true);
+
+        Logger newLogger = mock(Logger.class);
+        LogUtils.setLogger(newLogger);
+        LogUtils.logD("Dmessage");
+
+        verify(newLogger, times(1)).logD(anyString(), eq("Dmessage"));
+        verify(mockLogger, times(0)).logD(anyString(), anyString());
+    }
+
+    @Test
+    public void whenLoggerIsNullDoNothing() {
+        LogUtils.enable(true);
+
+        LogUtils.setLogger(null);
+        LogUtils.logD("Dmessage");
+
+        verify(mockLogger, times(1)).logD(anyString(), eq("Dmessage"));
+    }
+}

--- a/library/src/test/java/com/yayandroid/locationmanager/helper/LogUtilsTest.java
+++ b/library/src/test/java/com/yayandroid/locationmanager/helper/LogUtilsTest.java
@@ -66,14 +66,4 @@ public class LogUtilsTest {
         verify(newLogger, times(1)).logD(anyString(), eq("Dmessage"));
         verify(mockLogger, times(0)).logD(anyString(), anyString());
     }
-
-    @Test
-    public void whenLoggerIsNullDoNothing() {
-        LogUtils.enable(true);
-
-        LogUtils.setLogger(null);
-        LogUtils.logD("Dmessage");
-
-        verify(mockLogger, times(1)).logD(anyString(), eq("Dmessage"));
-    }
 }


### PR DESCRIPTION
Thanks for this library! Due to debugging issues we would like to use our custom logging when using this library. Usually App developers tend to use something like Timber. Therefore I proposed the following interface between LogUtils and `android.util.Log` to be able to replace the `DefaultLogger` with one which logs somewhere else (e.g. Timber), or even filters certain log levels.