### PR TITLE
Mark onStatusChanged as deprecated

### DIFF
--- a/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProvider.java
+++ b/library/src/main/java/com/yayandroid/locationmanager/providers/locationprovider/DefaultLocationProvider.java
@@ -232,6 +232,12 @@ public class DefaultLocationProvider extends LocationProvider
         }
     }
 
+    /**
+     * This callback will never be invoked on Android Q and above, and providers can be considered as always in the LocationProvider#AVAILABLE state.
+     *
+     * @see <a href="https://developer.android.com/reference/android/location/LocationListener#onStatusChanged(java.lang.String,%20int,%20android.os.Bundle)">LocationListener#onStatusChanged</a>
+     */
+    @Deprecated
     @Override
     public void onStatusChanged(String provider, int status, Bundle extras) {
         if (getListener() != null) {


### PR DESCRIPTION
[LocationListener#onStatusChanged reference](https://developer.android.com/reference/android/location/LocationListener#onStatusChanged(java.lang.String,%20int,%20android.os.Bundle))