### PR TITLE
use Gradle Daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - yes | sdkmanager "platforms;android-29"
 
 script:
-  - ./gradlew clean check --stacktrace --no-daemon
+  - ./gradlew clean check --stacktrace
   - ./gradlew build jacocoTestReport assembleAndroidTest
 
 after_success:


### PR DESCRIPTION
[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.
